### PR TITLE
CC-8833: Draft validator for the Splunk Sink Connector configuration

### DIFF
--- a/kafka-connect-splunk.iml
+++ b/kafka-connect-splunk.iml
@@ -12,10 +12,6 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.apache.kafka:connect-api:2.0.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.kafka:kafka-clients:2.0.0" level="project" />
-    <orderEntry type="library" name="Maven: org.lz4:lz4-java:1.4.1" level="project" />
-    <orderEntry type="library" name="Maven: javax.ws.rs:javax.ws.rs-api:2.1" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.9.5" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.9.5" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.9.0" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.splunk.kafka.connect</groupId>
     <artifactId>splunk-kafka-connect</artifactId>
-    <version>v1.1.0</version>
+    <version>v1.1.0-LAR</version>
     <name>splunk-kafka-connect</name>
 
     <properties>

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -207,6 +207,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         super(conf(), taskConfig);
         splunkToken = getPassword(TOKEN_CONF).value();
         splunkURI = getString(URI_CONF);
+        // TODO: Validate the https URI. Deleting the draft changes.
         raw = getBoolean(RAW_CONF);
         ack = getBoolean(ACK_CONF);
         indexes = getString(INDEX_CONF);

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 githash=@1e92a95
-gitbranch=release/1.0.x
-gitversion=v1.0.0
+gitbranch=release/1.1.x
+gitversion=v1.1.0


### PR DESCRIPTION
## Problem
The SSL configuration can be misconfigured within the Splunk Sink connector causing runtime exceptions when attempting to write to the HEC endpoints.

## Solution
Include validators for the Splunk Sink connector configuration to avoid runtime errors down the line.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
