### PR TITLE
CCLOG-1210: Validations for Splunk access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <groupId>com.github.splunk.kafka.connect</groupId>
-    <artifactId>kafka-connect-splunk</artifactId>
+    <artifactId>splunk-kafka-connect</artifactId>
     <version>v2.0.3.2</version>
-    <name>kafka-connect-splunk</name>
+    <name>splunk-kafka-connect</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.splunk.kafka.connect</groupId>
     <artifactId>kafka-connect-splunk</artifactId>
-    <version>v2.0.3.1</version>
+    <version>v2.0.3.2</version>
     <name>kafka-connect-splunk</name>
 
     <properties>
@@ -155,6 +155,12 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
@@ -15,21 +15,35 @@
  */
 package com.splunk.kafka.connect;
 
-import com.splunk.kafka.connect.VersionUtils;
+import com.splunk.hecclient.Hec;
+import com.splunk.hecclient.HecConfig;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class SplunkSinkConnector extends SinkConnector {
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SplunkSinkConnector extends SinkConnector {
     private static final Logger log = LoggerFactory.getLogger(SplunkSinkConnector.class);
     private Map<String, String> taskConfig;
+    private static final int CONFIG_VALIDATION_TIMEOUT_SECONDS = 10;
 
     @Override
     public void start(Map<String, String> taskConfig) {
@@ -66,4 +80,105 @@ public final class SplunkSinkConnector extends SinkConnector {
     public ConfigDef config() {
         return SplunkSinkConnectorConfig.conf();
     }
+
+    @Override
+    public Config validate(Map<String, String> connectorConfigs) {
+        Config config = super.validate(connectorConfigs);
+        if (config.configValues().stream().anyMatch(cv -> !cv.errorMessages().isEmpty())) {
+            return config;
+        }
+
+        Map<String, ConfigValue> configValues =
+            config.configValues()
+                .stream()
+                .collect(Collectors.toMap(
+                    ConfigValue::name,
+                    Function.identity()));
+
+        SplunkSinkConnectorConfig connectorConfig;
+        try {
+            connectorConfig = new SplunkSinkConnectorConfig(connectorConfigs);
+        } catch (Exception e) {
+            log.error("Validating configuration caught an exception", e);
+            return config;
+        }
+
+        validateAccess(connectorConfig, configValues);
+
+        return config;
+    }
+
+    /**
+     * We validate access by posting an empty payload to the Splunk endpoint.
+     *
+     * For a valid endpoint and a valid token, this returns a HTTP 400 Bad Request with the
+     * payload: {"text":"No data","code":5}
+     * For a valid endpoint and an invalid token, this returns a HTTP 403 Forbidden with the
+     * payload: {"text":"Invalid token","code":4}
+     * For an invalid hostname and other errors, the Java UnknownHostException and other similar
+     * Exceptions are thrown.
+     *
+     * @param connectorConfig The connector configuration
+     * @param configValues The configuration ConfigValues
+     */
+    private void validateAccess(SplunkSinkConnectorConfig connectorConfig, Map<String, ConfigValue> configValues) {
+        HecConfig config = connectorConfig.getHecConfig();
+
+        try (CloseableHttpClient httpClient = createHttpClient(config)) {
+            List<String> uris = config.getUris();
+            final String hecToken = config.getToken();
+
+            CountDownLatch latch = new CountDownLatch(config.getUris().size());
+            Map<String, String> validationFailedIndexers = new LinkedHashMap<>();
+
+            for (String uri : uris) {
+                log.info("Validating " + uri);
+                HttpPost request = new HttpPost(uri + "/services/collector");
+                request.setEntity(new StringEntity(""));
+
+                request.addHeader(HttpHeaders.AUTHORIZATION, String.format("Splunk %s", hecToken));
+
+                int status = -1;
+                try (CloseableHttpResponse response = httpClient.execute(request)) {
+                    status = response.getStatusLine().getStatusCode();
+                    if (status == 400) {
+                        log.info("Validation succeeded for indexer {}", uri);
+                    } else if (status == 403) {
+                        log.error("Invalid HEC token for indexer {}", uri);
+                        validationFailedIndexers.put(uri, response.getStatusLine().toString());
+                    } else {
+                        log.error("Validation failed for {}", uri);
+                        validationFailedIndexers.put(uri, response.getStatusLine().toString());
+                    }
+                } catch (Exception e) {
+                    log.error("Caught exception while validating", e);
+                    validationFailedIndexers.put(uri, e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            }
+
+            latch.await(CONFIG_VALIDATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            if (!validationFailedIndexers.isEmpty()) {
+                log.error("Validation failed: " + validationFailedIndexers);
+                configValues.get(SplunkSinkConnectorConfig.URI_CONF)
+                    .addErrorMessage("Validation Failed: " + validationFailedIndexers);
+                configValues.get(SplunkSinkConnectorConfig.TOKEN_CONF)
+                    .addErrorMessage("Validation Failed: " + validationFailedIndexers);
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error("Configuration validation error", e);
+            configValues.get(SplunkSinkConnectorConfig.URI_CONF)
+                .addErrorMessage("Configuration validation error: " + e.getMessage());
+            configValues.get(SplunkSinkConnectorConfig.TOKEN_CONF)
+                .addErrorMessage("Configuration validation error: " + e.getMessage());
+        }
+    }
+
+    // Enables mocking during testing
+    CloseableHttpClient createHttpClient(final HecConfig config) {
+        return Hec.createHttpClient(config);
+    }
+
 }

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 githash=
 gitbranch=2.0.3-cc
-gitversion=v2.0.3.1
+gitversion=v2.0.3.2

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 githash=
-gitbranch=2.0.3-cc
+gitbranch=2.0.3.x
 gitversion=v2.0.3.2

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -15,16 +15,83 @@
  */
 package com.splunk.kafka.connect;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-import java.util.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 class SplunkSinkConnecterTest {
+
+    private String SPLUNK_URI_HOST1 = "https://www.host1.com:1111/";
+
+    @Mock
+    CloseableHttpResponse validHttpResponse;
+
+    @Mock
+    CloseableHttpResponse unauthorizedHttpResponse;
+
+    @Mock
+    CloseableHttpResponse notFoundHttpResponse;
+
+    @Spy
+    SplunkSinkConnector connector;
+
+    @Spy
+    CloseableHttpClient httpClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        doReturn(httpClient)
+            .when(connector)
+            .createHttpClient(anyObject());
+
+        when(validHttpResponse.getStatusLine()).
+            thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST, "Bad Request"));
+        when(validHttpResponse.getEntity())
+            .thenReturn(new StringEntity("{\"text\":\"No data\",\"code\":5}", ContentType.APPLICATION_JSON));
+
+        when(unauthorizedHttpResponse.getStatusLine())
+            .thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_FORBIDDEN, "Unauthorized"));
+        when(unauthorizedHttpResponse.getEntity())
+            .thenReturn(new StringEntity("{\"text\":\"Invalid token\",\"code\":4}", ContentType.APPLICATION_JSON));
+
+        when(notFoundHttpResponse.getStatusLine()).
+            thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_NOT_FOUND, "Not Found"));
+        when(notFoundHttpResponse.getEntity())
+            .thenReturn(new StringEntity("<html>Not Found</html>", ContentType.APPLICATION_XHTML_XML));
+    }
 
     @Test
     void startStop() {
@@ -55,4 +122,93 @@ class SplunkSinkConnecterTest {
         ConfigDef config = connector.config();
         Assert.assertNotNull(config);
     }
+
+    @Test
+    public void testValidationEmptyConfig() {
+        Config config = new SplunkSinkConnector().validate(new HashMap<>());
+
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).isEmpty());
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).isEmpty());
+    }
+
+    @Test
+    public void testValidationSuccess() throws IOException {
+        Map<String, String> connectorConfig = getConnectorConfig();
+
+        doReturn(validHttpResponse)
+            .when(httpClient)
+            .execute(any());
+
+        Config config = connector.validate(connectorConfig);
+        for (ConfigValue value : config.configValues()) {
+            assertTrue(value.errorMessages().isEmpty());
+        }
+    }
+
+    @Test
+    public void testValidationFailure() throws IOException {
+        Map<String, String> connectorConfig = getConnectorConfig();
+
+        doReturn(unauthorizedHttpResponse)
+            .when(httpClient)
+            .execute(any());
+
+        Config config = connector.validate(connectorConfig);
+
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).isEmpty());
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).isEmpty());
+
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(SPLUNK_URI_HOST1));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(SPLUNK_URI_HOST1));
+    }
+
+    @Test
+    public void testMultipleValidationFailure() throws IOException {
+        Map<String, String> connectorConfig = getConnectorConfig();
+        String host2 = "https://www.host2.com:2222/";
+        String host3 = "https://www.host3.com:3333/";
+        connectorConfig.put(SplunkSinkConnectorConfig.URI_CONF,
+            SPLUNK_URI_HOST1 + "," + host2 + "," + host3);
+
+        doReturn(unauthorizedHttpResponse)
+            .doThrow(new UnknownHostException("Host not found"))
+            .doReturn(notFoundHttpResponse)
+            .when(httpClient)
+            .execute(any());
+
+        Config config = connector.validate(connectorConfig);
+
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+
+
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).isEmpty());
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).isEmpty());
+
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(SPLUNK_URI_HOST1));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(host2));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(host3));
+
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(SPLUNK_URI_HOST1));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(host2));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(host3));
+    }
+
+    private Map<String, String> getConnectorConfig() {
+        Map<String, String> connectorConfig = new HashMap<>();
+
+        connectorConfig.put(SinkConnector.TOPICS_CONFIG, "topic1");
+        connectorConfig.put(SplunkSinkConnectorConfig.URI_CONF, SPLUNK_URI_HOST1);
+        connectorConfig.put(SplunkSinkConnectorConfig.TOKEN_CONF, "token1");
+        connectorConfig.put(SplunkSinkConnectorConfig.SSL_VALIDATE_CERTIFICATES_CONF, "false");
+
+        return connectorConfig;
+    }
+
 }

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -15,7 +15,6 @@
  */
 package com.splunk.kafka.connect;
 
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -47,7 +46,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 class SplunkSinkConnecterTest {


### PR DESCRIPTION
## Problem
There are currently no validations for the Splunk endpoints and token within the Splunk Sink Connector.

## Solution
This PR includes validations for the Splunk endpoints and tokens within the connector

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
