### PR TITLE
CCLOG-1226: Remove unnecessary logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.github.splunk.kafka.connect</groupId>
     <artifactId>splunk-kafka-connect</artifactId>
-    <version>v2.0.3.2</version>
+    <version>v2.0.3.3</version>
     <name>splunk-kafka-connect</name>
 
     <properties>

--- a/src/main/java/com/splunk/hecclient/HecAckPoller.java
+++ b/src/main/java/com/splunk/hecclient/HecAckPoller.java
@@ -132,7 +132,7 @@ public final class HecAckPoller implements Poller {
         }
         
         if (resp.getText() == "Invalid data format") {
-            log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} events={}", channel, channel.getIndexer(), batch.toString());
+            log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} batch={}", channel, channel.getIndexer(), batch.getUUID());
             batch.commit();
             List<EventBatch> committedBatches = new ArrayList<>();
             committedBatches.add(batch);
@@ -316,7 +316,7 @@ public final class HecAckPoller implements Poller {
     }
 
     private void handleAckPollResponse(String resp, HecChannel channel) {
-        log.debug("ackPollResponse={}, channel={}", resp, channel);
+        log.debug("channel={}", channel);
         HecAckPollResponse ackPollResult;
         try {
             ackPollResult = jsonMapper.readValue(resp, HecAckPollResponse.class);

--- a/src/main/java/com/splunk/hecclient/HecAckPoller.java
+++ b/src/main/java/com/splunk/hecclient/HecAckPoller.java
@@ -316,7 +316,7 @@ public final class HecAckPoller implements Poller {
     }
 
     private void handleAckPollResponse(String resp, HecChannel channel) {
-        log.debug("channel={}", channel);
+        log.debug("Ack response for channel={}", channel);
         HecAckPollResponse ackPollResult;
         try {
             ackPollResult = jsonMapper.readValue(resp, HecAckPollResponse.class);

--- a/src/main/java/com/splunk/hecclient/Indexer.java
+++ b/src/main/java/com/splunk/hecclient/Indexer.java
@@ -185,7 +185,7 @@ final class Indexer implements IndexerInf {
                 logBackPressure();
             }
 
-            log.error("failed to post events resp={}, status={}", respPayload, status);
+            log.error("failed to post events status={}", status);
             JsonNode jsonNode;
             try {
                 jsonNode = jsonMapper.readTree(respPayload);

--- a/src/main/java/com/splunk/hecclient/ResponsePoller.java
+++ b/src/main/java/com/splunk/hecclient/ResponsePoller.java
@@ -69,10 +69,10 @@ public final class ResponsePoller implements Poller {
                 return;
             }
             if (response.getText() == "Invalid data format") {
-                log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} events={}", channel, channel.getIndexer(), batch.toString());
+                log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} batch={}", channel, channel.getIndexer(), batch.getUUID());
             }
         } catch (Exception ex) {
-            log.error("failed to parse response", resp, ex);
+            log.error("failed to parse response", ex);
             fail(channel, batch, ex);
             return;
         }

--- a/src/main/java/com/splunk/kafka/connect/KafkaRecordTracker.java
+++ b/src/main/java/com/splunk/kafka/connect/KafkaRecordTracker.java
@@ -55,7 +55,7 @@ final class KafkaRecordTracker {
      * @param batches the acked event batches
      */
     public void removeAckedEventBatches(final List<EventBatch> batches) {
-        log.debug("received acked event batches={}", batches);
+        log.debug("received acked event batches={}", batches.size());
         /* Loop all *assigned* partitions to find the lowest consecutive
          * HEC-commited offsets. A batch could contain events coming from a
          * variety of topic/partitions, and scanning those events coulb be

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -65,8 +65,6 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(connectorConfig.flushWindow > 0) {
             flushWindow = connectorConfig.flushWindow * 1000; // Flush window set to user configured value (Multiply by 1000 as all the calculations are done in milliseconds)
         }
-
-        log.info("kafka-connect-splunk task starts with config={}", connectorConfig);
     }
 
     @Override
@@ -361,7 +359,6 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if (hec != null) {
             hec.close();
         }
-        log.info("kafka-connect-splunk task ends with config={}", connectorConfig);
     }
 
     @Override

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 githash=
 gitbranch=2.0.3.x
-gitversion=v2.0.3.2
+gitversion=v2.0.3.3


### PR DESCRIPTION
## Problem
The Splunk Sink connector logs information that can be avoided.

## Solution
Remove unnecessary logging from the connector.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no
