### PR TITLE
CCLOG-1308: Bump connector version to address log4j CVE (#8)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,9 @@
+#!/usr/bin/env groovy
+/*
+ * Copyright [2021 - 2021] Confluent Inc.
+ */
+common {
+  slackChannel = '#connect-warn'
+  nodeLabel = 'docker-debian-jdk8'
+  downStreamValidate = false
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3,17 +3,21 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>connect-plugins-parent</artifactId>
+        <version>0.6.8</version>
+    </parent>
 
     <groupId>com.github.splunk.kafka.connect</groupId>
     <artifactId>splunk-kafka-connect</artifactId>
-    <version>v2.0.5</version>
+    <version>v2.0.5.1</version>
     <name>splunk-kafka-connect</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <java.version>1.8</java.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.3.2</junit.jupiter.version>
         <junit.vintage.version>5.3.2</junit.vintage.version>
@@ -152,6 +156,12 @@
             <version>3.7</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <reporting>
@@ -202,19 +212,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <configuration>
-                            <configLocation>google_checks.xml</configLocation>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
 

--- a/src/main/java/com/splunk/hecclient/HecAckPoller.java
+++ b/src/main/java/com/splunk/hecclient/HecAckPoller.java
@@ -132,7 +132,7 @@ public final class HecAckPoller implements Poller {
         }
         
         if (resp.getText() == "Invalid data format") {
-            log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} events={}", channel, channel.getIndexer(), batch.toString());
+            log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} batch={}", channel, channel.getIndexer(), batch.getUUID());
             batch.commit();
             List<EventBatch> committedBatches = new ArrayList<>();
             committedBatches.add(batch);
@@ -316,7 +316,7 @@ public final class HecAckPoller implements Poller {
     }
 
     private void handleAckPollResponse(String resp, HecChannel channel) {
-        log.debug("ackPollResponse={}, channel={}", resp, channel);
+        log.debug("Ack response for channel={}", channel);
         HecAckPollResponse ackPollResult;
         try {
             ackPollResult = jsonMapper.readValue(resp, HecAckPollResponse.class);

--- a/src/main/java/com/splunk/hecclient/Indexer.java
+++ b/src/main/java/com/splunk/hecclient/Indexer.java
@@ -188,7 +188,7 @@ final class Indexer implements IndexerInf {
                 logBackPressure();
             }
 
-            log.error("failed to post events resp={}, status={}", respPayload, status);
+            log.error("failed to post events status={}", status);
             JsonNode jsonNode;
             try {
                 jsonNode = jsonMapper.readTree(respPayload);

--- a/src/main/java/com/splunk/hecclient/ResponsePoller.java
+++ b/src/main/java/com/splunk/hecclient/ResponsePoller.java
@@ -69,10 +69,10 @@ public final class ResponsePoller implements Poller {
                 return;
             }
             if (response.getText() == "Invalid data format") {
-                log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} events={}", channel, channel.getIndexer(), batch.toString());
+                log.warn("Invalid Splunk HEC data format. Ignoring events. channel={} index={} batch={}", channel, channel.getIndexer(), batch.getUUID());
             }
         } catch (Exception ex) {
-            log.error("failed to parse response", resp, ex);
+            log.error("failed to parse response", ex);
             fail(channel, batch, ex);
             return;
         }

--- a/src/main/java/com/splunk/kafka/connect/KafkaRecordTracker.java
+++ b/src/main/java/com/splunk/kafka/connect/KafkaRecordTracker.java
@@ -55,7 +55,7 @@ final class KafkaRecordTracker {
      * @param batches the acked event batches
      */
     public void removeAckedEventBatches(final List<EventBatch> batches) {
-        log.debug("received acked event batches={}", batches);
+        log.debug("received acked event batches={}", batches.size());
         /* Loop all *assigned* partitions to find the lowest consecutive
          * HEC-commited offsets. A batch could contain events coming from a
          * variety of topic/partitions, and scanning those events coulb be

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
@@ -15,19 +15,30 @@
  */
 package com.splunk.kafka.connect;
 
-import com.splunk.kafka.connect.VersionUtils;
+import com.splunk.hecclient.Hec;
+import com.splunk.hecclient.HecConfig;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class SplunkSinkConnector extends SinkConnector {
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SplunkSinkConnector extends SinkConnector {
     private static final Logger log = LoggerFactory.getLogger(SplunkSinkConnector.class);
     private Map<String, String> taskConfig;
 
@@ -65,5 +76,101 @@ public final class SplunkSinkConnector extends SinkConnector {
     @Override
     public ConfigDef config() {
         return SplunkSinkConnectorConfig.conf();
+    }
+
+    @Override
+    public Config validate(Map<String, String> connectorConfigs) {
+        Config config = super.validate(connectorConfigs);
+        SplunkSinkConnectorConfig connectorConfig;
+        try {
+            connectorConfig = new SplunkSinkConnectorConfig(connectorConfigs);
+        } catch (Exception e) {
+            log.warn("Validating configuration caught an exception", e);
+            return config;
+        }
+
+        Map<String, ConfigValue> configValues =
+            config.configValues()
+                .stream()
+                .collect(Collectors.toMap(
+                    ConfigValue::name,
+                    Function.identity()));
+
+        validateAccess(connectorConfig, configValues);
+
+        return config;
+    }
+
+    /**
+     * We validate access by posting an empty payload to the Splunk endpoint.
+     *
+     * For a valid endpoint and a valid token, this returns a HTTP 400 Bad Request with the
+     * payload: {"text":"No data","code":5}
+     * For a valid endpoint and an invalid token, this returns a HTTP 403 Forbidden with the
+     * payload: {"text":"Invalid token","code":4}
+     * For an invalid hostname and other errors, the Java UnknownHostException and other similar
+     * Exceptions are thrown.
+     *
+     * @param connectorConfig The connector configuration
+     * @param configValues The configuration ConfigValues
+     */
+    private void validateAccess(SplunkSinkConnectorConfig connectorConfig, Map<String, ConfigValue> configValues) {
+        HecConfig hecConfig = connectorConfig.getHecConfig();
+
+        try (CloseableHttpClient httpClient = createHttpClient(hecConfig)) {
+            List<String> uris = hecConfig.getUris();
+
+            Map<String, String> validationFailedIndexers = new LinkedHashMap<>();
+
+            for (String uri : uris) {
+                log.trace("Validating " + uri);
+                HttpPost request = new HttpPost(uri + "/services/collector");
+                request.setEntity(new StringEntity(""));
+
+                request.addHeader(HttpHeaders.AUTHORIZATION, String.format("Splunk %s", hecConfig.getToken()));
+
+                int status = -1;
+                try (CloseableHttpResponse response = httpClient.execute(request)) {
+                    status = response.getStatusLine().getStatusCode();
+                    if (status == 400) {
+                        log.trace("Validation succeeded for indexer {}", uri);
+                    } else if (status == 403) {
+                        log.trace("Invalid HEC token for indexer {}", uri);
+                        validationFailedIndexers.put(uri, response.getStatusLine().toString());
+                    } else {
+                        log.trace("Validation failed for {}", uri);
+                        validationFailedIndexers.put(uri, response.getStatusLine().toString());
+                    }
+                } catch (Exception e) {
+                    log.error("Caught exception while validating", e);
+                    validationFailedIndexers.put(uri, e.getMessage());
+                }
+            }
+
+            if (!validationFailedIndexers.isEmpty()) {
+                log.trace("Validation failed: " + validationFailedIndexers);
+                recordErrors(configValues,
+                    "Validation Failed: " + validationFailedIndexers,
+                    SplunkSinkConnectorConfig.URI_CONF,
+                    SplunkSinkConnectorConfig.TOKEN_CONF);
+            }
+        } catch (IOException e) {
+            log.error("Configuration validation error", e);
+            recordErrors(configValues,
+                "Configuration validation error: " + e.getMessage(),
+                SplunkSinkConnectorConfig.URI_CONF,
+                SplunkSinkConnectorConfig.TOKEN_CONF);
+        }
+    }
+
+    // Enables mocking during testing
+    CloseableHttpClient createHttpClient(final HecConfig config) {
+        return Hec.createHttpClient(config);
+    }
+
+    void recordErrors(Map<String, ConfigValue> configValues, String message, String...keys) {
+        for (String key : keys) {
+            configValues.get(key).addErrorMessage(message);
+        }
     }
 }

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkTask.java
@@ -65,8 +65,6 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if(connectorConfig.flushWindow > 0) {
             flushWindow = connectorConfig.flushWindow * 1000; // Flush window set to user configured value (Multiply by 1000 as all the calculations are done in milliseconds)
         }
-
-        log.info("kafka-connect-splunk task starts with config={}", connectorConfig);
     }
 
     @Override
@@ -366,7 +364,6 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
         if (hec != null) {
             hec.close();
         }
-        log.info("kafka-connect-splunk task ends with config={}", connectorConfig);
     }
 
     @Override
@@ -404,7 +401,7 @@ public final class SplunkSinkTask extends SinkTask implements PollerCallback {
                 event.setTied(record);
                 event.addFields(connectorConfig.enrichments);
             } catch(Exception e) {
-                log.error("event does not follow correct HEC pre-formatted format: {}", record.value().toString());
+                log.trace("event does not follow correct HEC pre-formatted format: {}", record.value().toString());
                 event = createHECEventNonFormatted(record);
             }
         } else {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 githash=
-gitbranch=release/2.0.x
-gitversion=v2.0.5
+gitbranch=2.0.5.x
+gitversion=v2.0.5.1

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -15,16 +15,81 @@
  */
 package com.splunk.kafka.connect;
 
+import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
-import java.util.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 class SplunkSinkConnecterTest {
+
+    private String SPLUNK_URI_HOST1 = "https://www.host1.com:1111/";
+
+    @Mock
+    CloseableHttpResponse validHttpResponse;
+
+    @Mock
+    CloseableHttpResponse unauthorizedHttpResponse;
+
+    @Mock
+    CloseableHttpResponse notFoundHttpResponse;
+
+    @Spy
+    SplunkSinkConnector connector;
+
+    @Spy
+    CloseableHttpClient httpClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        doReturn(httpClient)
+            .when(connector)
+            .createHttpClient(anyObject());
+
+        when(validHttpResponse.getStatusLine()).
+            thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST, "Bad Request"));
+        when(validHttpResponse.getEntity())
+            .thenReturn(new StringEntity("{\"text\":\"No data\",\"code\":5}", ContentType.APPLICATION_JSON));
+
+        when(unauthorizedHttpResponse.getStatusLine())
+            .thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_FORBIDDEN, "Unauthorized"));
+        when(unauthorizedHttpResponse.getEntity())
+            .thenReturn(new StringEntity("{\"text\":\"Invalid token\",\"code\":4}", ContentType.APPLICATION_JSON));
+
+        when(notFoundHttpResponse.getStatusLine()).
+            thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_NOT_FOUND, "Not Found"));
+        when(notFoundHttpResponse.getEntity())
+            .thenReturn(new StringEntity("<html>Not Found</html>", ContentType.APPLICATION_XHTML_XML));
+    }
 
     @Test
     void startStop() {
@@ -55,4 +120,93 @@ class SplunkSinkConnecterTest {
         ConfigDef config = connector.config();
         Assert.assertNotNull(config);
     }
+
+    @Test
+    public void testValidationEmptyConfig() {
+        Config config = new SplunkSinkConnector().validate(new HashMap<>());
+
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).isEmpty());
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).isEmpty());
+    }
+
+    @Test
+    public void testValidationSuccess() throws IOException {
+        Map<String, String> connectorConfig = getConnectorConfig();
+
+        doReturn(validHttpResponse)
+            .when(httpClient)
+            .execute(any());
+
+        Config config = connector.validate(connectorConfig);
+        for (ConfigValue value : config.configValues()) {
+            assertTrue(value.errorMessages().isEmpty());
+        }
+    }
+
+    @Test
+    public void testValidationFailure() throws IOException {
+        Map<String, String> connectorConfig = getConnectorConfig();
+
+        doReturn(unauthorizedHttpResponse)
+            .when(httpClient)
+            .execute(any());
+
+        Config config = connector.validate(connectorConfig);
+
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).isEmpty());
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).isEmpty());
+
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(SPLUNK_URI_HOST1));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(SPLUNK_URI_HOST1));
+    }
+
+    @Test
+    public void testMultipleValidationFailure() throws IOException {
+        Map<String, String> connectorConfig = getConnectorConfig();
+        String host2 = "https://www.host2.com:2222/";
+        String host3 = "https://www.host3.com:3333/";
+        connectorConfig.put(SplunkSinkConnectorConfig.URI_CONF,
+            SPLUNK_URI_HOST1 + "," + host2 + "," + host3);
+
+        doReturn(unauthorizedHttpResponse)
+            .doThrow(new UnknownHostException("Host not found"))
+            .doReturn(notFoundHttpResponse)
+            .when(httpClient)
+            .execute(any());
+
+        Config config = connector.validate(connectorConfig);
+
+        Map<String, List<String>> errorMessages = config.configValues().stream()
+            .collect(Collectors.toMap(ConfigValue::name, ConfigValue::errorMessages));
+
+
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).isEmpty());
+        assertFalse(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).isEmpty());
+
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(SPLUNK_URI_HOST1));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(host2));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.URI_CONF).get(0).contains(host3));
+
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(SPLUNK_URI_HOST1));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(host2));
+        assertTrue(errorMessages.get(SplunkSinkConnectorConfig.TOKEN_CONF).get(0).contains(host3));
+    }
+
+    private Map<String, String> getConnectorConfig() {
+        Map<String, String> connectorConfig = new HashMap<>();
+
+        connectorConfig.put(SinkConnector.TOPICS_CONFIG, "topic1");
+        connectorConfig.put(SplunkSinkConnectorConfig.URI_CONF, SPLUNK_URI_HOST1);
+        connectorConfig.put(SplunkSinkConnectorConfig.TOKEN_CONF, "token1");
+        connectorConfig.put(SplunkSinkConnectorConfig.SSL_VALIDATE_CERTIFICATES_CONF, "false");
+
+        return connectorConfig;
+    }
+
 }


### PR DESCRIPTION
## Problem
The Splunk Sink connector needs to update the log4j library.

## Solution
Rebase the Splunk Sink connector on the bumped up 2.0.5

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests
