### PR TITLE
CCLOG-1248: Bump up Splunk Sink connector version

### DIFF
--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,3 +1,3 @@
 githash=
 gitbranch=2.0.5.x
-gitversion=v2.0.5.1
+gitversion=v2.0.5.2


### PR DESCRIPTION
## Problem
The Splunk Sink connector version needs to be bumped up explicitly

## Solution
Bump up the Splunk Sink connector version

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

