### PR TITLE
RCCA-9576 validate in case of success response

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
@@ -208,7 +208,7 @@ public class SplunkSinkConnector extends SinkConnector {
             int status = -1;
             try (CloseableHttpResponse response = httpClient.execute(request)) {
                 status = response.getStatusLine().getStatusCode();
-                if (status == 400) {
+                if (status == 400 || status == 200) {
                     log.trace("Validation succeeded for collector {}", uri);
                 } else if (status == 403) {
                     log.trace("Invalid HEC token for collector {}", uri);

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -156,6 +156,21 @@ class SplunkSinkConnecterTest {
     }
 
     @Test
+    public void testValidationSuccessWithSuccessResponse() throws IOException {
+        Map<String, String> connectorConfig = getConnectorConfig();
+
+        doReturn(okHttpResponse)
+                .doReturn(okHttpResponse)
+                .when(httpClient)
+                .execute(any());
+
+        Config config = connector.validate(connectorConfig);
+        for (ConfigValue value : config.configValues()) {
+            assertTrue(value.errorMessages().isEmpty());
+        }
+    }
+
+    @Test
     public void testConnectionFailure() throws IOException {
         Map<String, String> connectorConfig = getConnectorConfig();
 


### PR DESCRIPTION
## Problem
We were throwing invalid configuration in case of success response too.
Kink to RCCA: https://confluentinc.atlassian.net/browse/RCCA-9576

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
