### PR TITLE
Added timeout to httpclient in splunk sink

### DIFF
--- a/src/main/java/com/splunk/hecclient/Hec.java
+++ b/src/main/java/com/splunk/hecclient/Hec.java
@@ -274,6 +274,7 @@ public class Hec implements HecInf {
             return new HttpClientBuilder().setDisableSSLCertVerification(config.getDisableSSLCertVerification())
                     .setMaxConnectionPoolSizePerDestination(poolSizePerDest)
                     .setMaxConnectionPoolSize(poolSizePerDest * config.getUris().size())
+                    .setSocketTimeout(config.getSocketTimeout())
                     .build();
         }
 
@@ -286,6 +287,7 @@ public class Hec implements HecInf {
                 .setMaxConnectionPoolSizePerDestination(poolSizePerDest)
                 .setMaxConnectionPoolSize(poolSizePerDest * config.getUris().size())
                 .setSslContext(context)
+                .setSocketTimeout(config.getSocketTimeout())
                 .build();
         }
         else {


### PR DESCRIPTION
## Problem
Default timeout is not set for httpclient in validate call. Timeout is exposed as a connector config, but it is not passed to httpclient during initialization.

## Solution
Passed timeout to httpclient used in validate call

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
