### PR TITLE
Added config to disable hostname verification

### DIFF
--- a/src/main/java/com/splunk/hecclient/Hec.java
+++ b/src/main/java/com/splunk/hecclient/Hec.java
@@ -277,6 +277,7 @@ public class Hec implements HecInf {
                     .setSocketTimeout(config.getSocketTimeout())
                     .setConnectionTimeout(config.getConnectionTimeout())
                     .setConnectionRequestTimeout(config.getConnectionRequestTimeout())
+                    .setDisableHostnameVerification(config.getDisableHostnameVerification())
                     .build();
         }
 
@@ -292,6 +293,7 @@ public class Hec implements HecInf {
                 .setSocketTimeout(config.getSocketTimeout())
                 .setConnectionTimeout(config.getConnectionTimeout())
                 .setConnectionRequestTimeout(config.getConnectionRequestTimeout())
+                .setDisableHostnameVerification(config.getDisableHostnameVerification())
                 .build();
         }
         else {

--- a/src/main/java/com/splunk/hecclient/HecConfig.java
+++ b/src/main/java/com/splunk/hecclient/HecConfig.java
@@ -38,6 +38,7 @@ public final class HecConfig {
     private String trustStorePath;
     private String trustStorePassword;
     private int lbPollInterval = 120; // in seconds
+    private Boolean disableHostnameVerification;
 
     public HecConfig(List<String> uris, String token) {
         this.uris = uris;
@@ -197,5 +198,13 @@ public final class HecConfig {
     public HecConfig setBackoffThresholdSeconds(int backoffSeconds) {
         backoffThresholdSeconds = backoffSeconds * 1000;
         return this;
+    }
+
+    public boolean getDisableHostnameVerification() {
+        return this.disableHostnameVerification;
+    }
+
+    public void setDisableHostnameVerification(Boolean disableHostnameVerification) {
+        this.disableHostnameVerification = disableHostnameVerification;
     }
 }

--- a/src/main/java/com/splunk/hecclient/HttpClientBuilder.java
+++ b/src/main/java/com/splunk/hecclient/HttpClientBuilder.java
@@ -18,6 +18,7 @@ package com.splunk.hecclient;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -37,6 +38,7 @@ public final class HttpClientBuilder {
     private int connectionTimeout = 60; // in seconds
     private int socketSendBufferSize = 8 * 1024 * 1024; // in bytes
     private boolean disableSSLCertVerification = false;
+    private boolean disableHostnameVerification = false;
     private SSLContext sslContext = null;
 
     public HttpClientBuilder setMaxConnectionPoolSizePerDestination(int connections) {
@@ -72,6 +74,15 @@ public final class HttpClientBuilder {
     public HttpClientBuilder setDisableSSLCertVerification(boolean disableVerification) {
         disableSSLCertVerification = disableVerification;
         return this;
+    }
+
+    public HttpClientBuilder setDisableHostnameVerification(boolean disableHostnameVerification) {
+        this.disableHostnameVerification = disableHostnameVerification;
+        return this;
+    }
+
+    public Boolean getDisableHostnameVerification() {
+        return this.disableHostnameVerification;
     }
 
     public HttpClientBuilder setSslContext(SSLContext context) {
@@ -138,6 +149,9 @@ public final class HttpClientBuilder {
         if (this.sslContext == null) {
             return null; // use system default one
         } else {
+            if (this.getDisableHostnameVerification()) {
+                return new SSLConnectionSocketFactory(this.sslContext, NoopHostnameVerifier.INSTANCE);
+            }
             return new SSLConnectionSocketFactory(this.sslContext);
         }
     }

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -77,7 +77,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     // Trust store
     static final String SSL_TRUSTSTORE_PATH_CONF = "splunk.hec.ssl.trust.store.path";
     static final String SSL_TRUSTSTORE_PASSWORD_CONF = "splunk.hec.ssl.trust.store.password";
-    static final String DISABLE_HOSTNAME_VERIFICATION_CONF = "disable.hostname.verification";
+    static final String DISABLE_HOSTNAME_VERIFICATION_CONF = "splunk.disable.hostname.verification";
     //Headers
     static final String HEADER_SUPPORT_CONF = "splunk.header.support";
     static final String HEADER_CUSTOM_CONF = "splunk.header.custom";

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -17,12 +17,9 @@ package com.splunk.kafka.connect;
 
 import com.splunk.hecclient.HecConfig;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.sink.SinkTask;
 
@@ -30,8 +27,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.apache.kafka.common.config.SslConfigs.addClientSslSupport;
 
 public final class SplunkSinkConnectorConfig extends AbstractConfig {
     // General

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -297,7 +297,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(SSL_VALIDATE_CERTIFICATES_CONF, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.MEDIUM, SSL_VALIDATE_CERTIFICATES_DOC)
                 .define(SSL_TRUSTSTORE_PATH_CONF, ConfigDef.Type.STRING, "", ConfigDef.Importance.HIGH, SSL_TRUSTSTORE_PATH_DOC)
                 .define(SSL_TRUSTSTORE_PASSWORD_CONF, ConfigDef.Type.PASSWORD, "", ConfigDef.Importance.HIGH, SSL_TRUSTSTORE_PASSWORD_DOC)
-                .define(DISABLE_HOSTNAME_VERIFICATION_CONF, ConfigDef.Type.BOOLEAN, "", ConfigDef.Importance.LOW, DISABLE_HOSTNAME_VERIFICATION_DOC)
+                .define(DISABLE_HOSTNAME_VERIFICATION_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, DISABLE_HOSTNAME_VERIFICATION_DOC)
                 .define(EVENT_TIMEOUT_CONF, ConfigDef.Type.INT, 300, ConfigDef.Importance.MEDIUM, EVENT_TIMEOUT_DOC)
                 .define(ACK_POLL_INTERVAL_CONF, ConfigDef.Type.INT, 10, ConfigDef.Importance.MEDIUM, ACK_POLL_INTERVAL_DOC)
                 .define(ACK_POLL_THREADS_CONF, ConfigDef.Type.INT, 2, ConfigDef.Importance.MEDIUM, ACK_POLL_THREADS_DOC)

--- a/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
+++ b/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
@@ -44,6 +44,19 @@ public class HttpClientBuilderTest {
                 .build();
         Assert.assertNotNull(client);
     }
+
+    @Test
+    public void buildWithDisabledHostnameVerification() {
+        HttpClientBuilder builder = new HttpClientBuilder();
+        CloseableHttpClient client = builder.setMaxConnectionPoolSizePerDestination(1)
+            .setMaxConnectionPoolSize(2)
+            .setSocketSendBufferSize(1024)
+            .setSocketTimeout(120)
+            .setDisableSSLCertVerification(false)
+            .setDisableHostnameVerification(false)
+            .build();
+        Assert.assertNotNull(client);
+    }
     @Test
     public void buildSecureCustomKeystore() {
         HttpClientBuilder builder = new HttpClientBuilder();

--- a/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
+++ b/src/test/java/com/splunk/hecclient/HttpClientBuilderTest.java
@@ -53,7 +53,7 @@ public class HttpClientBuilderTest {
             .setSocketSendBufferSize(1024)
             .setSocketTimeout(120)
             .setDisableSSLCertVerification(false)
-            .setDisableHostnameVerification(false)
+            .setDisableHostnameVerification(true)
             .build();
         Assert.assertNotNull(client);
     }

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -75,7 +75,7 @@ public class SplunkSinkConnectorConfigTest {
     }
 
     @Test
-    public void getDisableHostnameVerificatoinConfig() {
+    public void getDisableHostnameVerificationConfig() {
             UnitUtil uu = new UnitUtil(0);
             Map<String, String> taskConfig = uu.createTaskConfig();
             taskConfig.put(SplunkSinkConnectorConfig.DISABLE_HOSTNAME_VERIFICATION_CONF, String.valueOf(false));
@@ -83,7 +83,7 @@ public class SplunkSinkConnectorConfigTest {
             HecConfig config = connectorConfig.getHecConfig();
             Assert.assertEquals(false, config.getDisableSSLCertVerification());
 
-            taskConfig.put(SplunkSinkConnectorConfig.DISABLE_HOSTNAME_VERIFICATION_CONF, String.valueOf(false));
+            taskConfig.put(SplunkSinkConnectorConfig.DISABLE_HOSTNAME_VERIFICATION_CONF, String.valueOf(true));
             connectorConfig = new SplunkSinkConnectorConfig(taskConfig);
             config = connectorConfig.getHecConfig();
             Assert.assertEquals(true, config.getDisableSSLCertVerification());

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnectorConfigTest.java
@@ -75,6 +75,22 @@ public class SplunkSinkConnectorConfigTest {
     }
 
     @Test
+    public void getDisableHostnameVerificatoinConfig() {
+            UnitUtil uu = new UnitUtil(0);
+            Map<String, String> taskConfig = uu.createTaskConfig();
+            taskConfig.put(SplunkSinkConnectorConfig.DISABLE_HOSTNAME_VERIFICATION_CONF, String.valueOf(false));
+            SplunkSinkConnectorConfig connectorConfig = new SplunkSinkConnectorConfig(taskConfig);
+            HecConfig config = connectorConfig.getHecConfig();
+            Assert.assertEquals(false, config.getDisableSSLCertVerification());
+
+            taskConfig.put(SplunkSinkConnectorConfig.DISABLE_HOSTNAME_VERIFICATION_CONF, String.valueOf(false));
+            connectorConfig = new SplunkSinkConnectorConfig(taskConfig);
+            config = connectorConfig.getHecConfig();
+            Assert.assertEquals(true, config.getDisableSSLCertVerification());
+
+    }
+
+    @Test
     public void getHecConfigCustomKeystore() {
         UnitUtil uu = new UnitUtil(1);
 


### PR DESCRIPTION
## Problem
Added a config disable hostname verification to disable hostname verification using apache http client used underneath.
This is needed in cases where request is routed from connector to splunk via an LB like haproxy and the SSL certificate does not have the IP of the haproxy in the SAN list. 
In such cases, user wants to disable the hostname verification when using SSL.

Ref: #inc_rcca-15799-http-sink-ssl-errors-lcc-m2866x
RCCA-15799

## Solution
Passed a low level config disable.hostname.verification to the connector which is used to create the hostname verifier.
In case this config is true, hostname verifier used in apache http client is `NoopHostnameVerifier`, otherwise the default hostname verifier is used.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
