### PR TITLE
updated snappy-java version to 1.1.10.5 to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.3.2</junit.jupiter.version>
-        <snappy.java.version>1.1.10.1</snappy.java.version>
+        <snappy.java.version>1.1.10.4</snappy.java.version>
         <junit.vintage.version>5.3.2</junit.vintage.version>
         <junit.platform.version>1.3.2</junit.platform.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.3.2</junit.jupiter.version>
+        <snappy.java.version>1.1.10.1</snappy.java.version>
         <junit.vintage.version>5.3.2</junit.vintage.version>
         <junit.platform.version>1.3.2</junit.platform.version>
     </properties>
@@ -43,6 +44,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>2.8.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.java.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>connect-plugins-parent</artifactId>
-        <version>0.6.8</version>
+        <version>0.9.23</version>
     </parent>
 
     <groupId>com.github.splunk.kafka.connect</groupId>
@@ -18,9 +18,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>4.13.2</junit.version
         <junit.jupiter.version>5.3.2</junit.jupiter.version>
-        <snappy.java.version>1.1.10.4</snappy.java.version>
         <junit.vintage.version>5.3.2</junit.vintage.version>
         <junit.platform.version>1.3.2</junit.platform.version>
     </properties>
@@ -44,12 +43,6 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>2.8.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${snappy.java.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <junit.version>4.13.2</junit.version
+        <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.3.2</junit.jupiter.version>
         <junit.vintage.version>5.3.2</junit.vintage.version>
         <junit.platform.version>1.3.2</junit.platform.version>


### PR DESCRIPTION
## Problem
CVE-2023-34453 using snappy-java to 1.1.7.1

## Solution
Fix for CVE CVE-2023-34453 updating snappy-java to 1.1.10.5 by updating connect-plugins-parent to 0.9.23

```
[INFO] --------< com.github.splunk.kafka.connect:splunk-kafka-connect >--------
[INFO] Building splunk-kafka-connect v2.0.5.1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ splunk-kafka-connect ---
[INFO] com.github.splunk.kafka.connect:splunk-kafka-connect:jar:v2.0.5.1
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.10.5:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.5.1:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5:compile
[INFO] +- org.apache.kafka:connect-api:jar:2.8.1:compile
[INFO] |  +- org.apache.kafka:kafka-clients:jar:6.0.3-ccs:compile
[INFO] |  |  +- com.github.luben:zstd-jni:jar:1.4.4-7:compile
[INFO] |  |  \- org.lz4:lz4-java:jar:1.7.1:compile
[INFO] |  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:compile
[INFO] +- org.xerial.snappy:snappy-java:jar:1.1.10.1:compile
[INFO] +- org.junit.jupiter:junit-jupiter-api:jar:5.3.2:test
[INFO] |  +- org.opentest4j:opentest4j:jar:1.1.1:test
[INFO] |  \- org.junit.platform:junit-platform-commons:jar:1.3.2:test
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.junit.platform:junit-platform-launcher:jar:1.3.2:test
[INFO] |  \- org.junit.platform:junit-platform-engine:jar:1.3.2:test
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.3.2:test
[INFO] +- org.junit.vintage:junit-vintage-engine:jar:5.3.2:test
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  \- org.apache.httpcomponents:httpcore:jar:4.4.13:compile
[INFO] +- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- commons-codec:commons-codec:jar:1.14:compile
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
[INFO] |  \- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.26:test
[INFO] +- org.slf4j:slf4j-api:jar:1.7.26:compile
[INFO] +- commons-cli:commons-cli:jar:1.4:compile
[INFO] +- org.apiguardian:apiguardian-api:jar:1.0.0:test
[INFO] +- org.apache.commons:commons-lang3:jar:3.7:compile
[INFO] +- org.mockito:mockito-core:jar:2.23.4:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.9.3:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.9.3:test
[INFO] |  \- org.objenesis:objenesis:jar:2.6:test
[INFO] +- io.confluent:common-utils:jar:6.0.3:compile
[INFO] \- io.confluent:assembly-plugin-boilerplate:zip:resources:6.0.3:provided
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:17 min
[INFO] Finished at: 2024-03-08T13:57:32+05:30
[INFO] ------------------------------------------------------------------------
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
