### PR TITLE
Fix CVEs CVE-2022-42003, CVE-2021-46877, CVE-2022-42004, CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.1</version>
+            <version>2.13.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
+            <version>2.13.4.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.5</version>
+            <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
updated com.fasterxml.jackson.core:jackson-databind to 2.15.3 to fix CVEs CVE-2022-42003, CVE-2021-46877, CVE-2022-42004, CVE-2020-36518


## Solution
updated com.fasterxml.jackson.core:jackson-databind to 2.15.3 to fix CVEs CVE-2022-42003, CVE-2021-46877, CVE-2022-42004, CVE-2020-36518


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
