### PR TITLE
Updated validate socket timeout to 5s(configurable as internal config)

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
@@ -100,7 +100,7 @@ public class SplunkSinkConnector extends SinkConnector {
                     ConfigValue::name,
                     Function.identity()));
 
-        HecConfig hecConfig = connectorConfig.getHecConfig();
+        HecConfig hecConfig = connectorConfig.getHecConfigForValidate();
         try (CloseableHttpClient httpClient = createHttpClient(hecConfig)) {
 
             if (!validateCollector(httpClient, hecConfig, configValues)) {


### PR DESCRIPTION
## Problem
Validation socket timeout was 60s earlier causing 500 while making /validate call from mothership in case of timeouts.

## Solution
Made socket timeout for validate calls configurable to 5s

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
