### PR TITLE
Update package path in service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -14,4 +14,4 @@ semaphore:
 code_artifact:
   enable: true
   package_paths:
-    - maven-snapshots/maven/io.confluent/splunk-kafka-connect
+    - maven-snapshots/maven/com.github.splunk.kafka.connect/splunk-kafka-connect


### PR DESCRIPTION
Maven Group Id is **_com.github.splunk.kafka.connect_** in pom.xml, so we need to update the package path where docker image from semaphore build will be stored to rightly push the image.
Currently (without this change), the build is failing ([ref](https://semaphore.ci.confluent.io/workflows/effef302-418b-479d-a837-c740f4fea927?pipeline_id=317078b7-61ef-4caf-98b1-ef65db94ea07)).