### PR TITLE
SUP-236: Validate HEC truststore configs

### DIFF
--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnector.java
@@ -17,6 +17,7 @@ package com.splunk.kafka.connect;
 
 import com.splunk.hecclient.Hec;
 import com.splunk.hecclient.HecConfig;
+import com.splunk.hecclient.HecException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -109,6 +110,13 @@ public class SplunkSinkConnector extends SinkConnector {
 
             validateAccess(httpClient, hecConfig, configValues);
 
+        } catch (HecException e) {
+            log.error("Configuration validation error", e);
+            recordErrors(
+                    configValues,
+                    "Configuration validation error: " + e.getMessage(),
+                    SplunkSinkConnectorConfig.SSL_TRUSTSTORE_PATH_CONF, SplunkSinkConnectorConfig.SSL_TRUSTSTORE_PASSWORD_CONF
+            );
         } catch (IOException e) {
             log.error("Configuration validation error", e);
             recordErrors(


### PR DESCRIPTION
## Problem
When HEC trust store configuration is invalid, we were not returning an appropriate error message.


## Solution
Add a validation and return a http 400 response with a useful error message.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy
Tested manually using kafka-docker-playground.
Added unit test.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [X] kafka-docker-playground
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
