### PR TITLE
Fix validation timeouts

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <parent>
-    <artifactId>connect-plugins-parent</artifactId>
-    <groupId>io.confluent</groupId>
-    <version>0.9.23</version>
-    <relativePath>../pom.xml/pom.xml</relativePath>
-  </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.splunk.kafka.connect</groupId>
   <artifactId>splunk-kafka-connect</artifactId>
   <name>splunk-kafka-connect</name>
-  <version>v2.0.5.1</version>
+  <version>v2.0.5</version>
   <build>
     <plugins>
       <plugin>
@@ -46,25 +40,19 @@
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**</exclude>
-          </excludes>
-        </configuration>
+        <version>2.17</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <configLocation>google_checks.xml</configLocation>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -196,34 +184,6 @@
       <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>byte-buddy</artifactId>
-          <groupId>net.bytebuddy</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>byte-buddy-agent</artifactId>
-          <groupId>net.bytebuddy</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>objenesis</artifactId>
-          <groupId>org.objenesis</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.confluent</groupId>
-      <artifactId>assembly-plugin-boilerplate</artifactId>
-      <version>7.5.2</version>
-      <type>zip</type>
-      <classifier>resources</classifier>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
   <reporting>
     <plugins>
@@ -235,6 +195,7 @@
   </reporting>
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.13.2</junit.version>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>connect-plugins-parent</artifactId>
+    <groupId>io.confluent</groupId>
+    <version>0.9.23</version>
+    <relativePath>../pom.xml/pom.xml</relativePath>
+  </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.splunk.kafka.connect</groupId>
   <artifactId>splunk-kafka-connect</artifactId>
   <name>splunk-kafka-connect</name>
-  <version>v2.0.5</version>
+  <version>v2.0.5.1</version>
   <build>
     <plugins>
       <plugin>
@@ -40,19 +46,25 @@
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <configLocation>google_checks.xml</configLocation>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -184,6 +196,34 @@
       <version>1.0.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>byte-buddy</artifactId>
+          <groupId>net.bytebuddy</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>byte-buddy-agent</artifactId>
+          <groupId>net.bytebuddy</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>objenesis</artifactId>
+          <groupId>org.objenesis</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>assembly-plugin-boilerplate</artifactId>
+      <version>7.5.2</version>
+      <type>zip</type>
+      <classifier>resources</classifier>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <reporting>
     <plugins>
@@ -195,7 +235,6 @@
   </reporting>
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <java.version>1.8</java.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.13.2</junit.version>

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -49,6 +49,9 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     static final String SOCKET_TIMEOUT_CONF = "splunk.hec.socket.timeout"; // seconds
     static final String CONNECTION_TIMEOUT_CONF = "splunk.hec.connection.timeout"; // seconds
     static final String CONNECTION_REQUEST_TIMEOUT_CONF = "splunk.hec.connection.request.timeout"; // seconds
+    static final String VALIDATION_TIMEOUT_SECOND = "validation.timeout.second";
+    //10 second timeout for all validation operations to prevent hanging
+    static final int VALIDATION_TIMEOUT_SECOND_DEFAULT = 10;
     static final String SSL_VALIDATE_CERTIFICATES_CONF = "splunk.hec.ssl.validate.certs";
     static final String ENABLE_COMPRESSSION_CONF = "splunk.hec.enable.compression";
     // Acknowledgement Parameters
@@ -194,6 +197,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     final int maxBatchSize;
     final boolean httpKeepAlive;
     final int numberOfThreads;
+    final int validationTimeoutSeconds;
     final int socketTimeout;
     final int connectionTimeout;
     final int connectionRequestTimeout;
@@ -251,6 +255,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         flushWindow = getInt(FLUSH_WINDOW_CONF);
         totalHecChannels = getInt(TOTAL_HEC_CHANNEL_CONF);
         socketTimeout = getInt(SOCKET_TIMEOUT_CONF);
+        validationTimeoutSeconds = getInt(VALIDATION_TIMEOUT_SECOND);
         connectionTimeout = getInt(CONNECTION_TIMEOUT_CONF);
         connectionRequestTimeout = getInt(CONNECTION_REQUEST_TIMEOUT_CONF);
         enrichments = parseEnrichments(getString(ENRICHMENT_CONF));
@@ -313,6 +318,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(HEADER_SOURCETYPE_CONF, ConfigDef.Type.STRING, "splunk.header.sourcetype", ConfigDef.Importance.MEDIUM, HEADER_SOURCETYPE_DOC)
                 .define(HEADER_HOST_CONF, ConfigDef.Type.STRING, "splunk.header.host", ConfigDef.Importance.MEDIUM, HEADER_HOST_DOC)
                 .define(LB_POLL_INTERVAL_CONF, ConfigDef.Type.INT, 120, ConfigDef.Importance.LOW, LB_POLL_INTERVAL_DOC)
+                .defineInternal(VALIDATION_TIMEOUT_SECOND, ConfigDef.Type.INT, VALIDATION_TIMEOUT_SECOND_DEFAULT, ConfigDef.Importance.LOW)
                 .define(ENABLE_COMPRESSSION_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, ENABLE_COMPRESSSION_DOC);
     }
 
@@ -342,8 +348,6 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
 
     public HecConfig getHecConfigForValidate() {
         HecConfig config = new HecConfig(Arrays.asList(splunkURI.split(",")), splunkToken);
-        // 10 second timeouts for all validation operations to prevent hanging
-        int validationTimeoutSeconds = 10;
         config.setDisableSSLCertVerification(!validateCertificates)
             .setSocketTimeout(validationTimeoutSeconds)
             .setConnectionTimeout(validationTimeoutSeconds)

--- a/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
+++ b/src/main/java/com/splunk/kafka/connect/SplunkSinkConnectorConfig.java
@@ -47,8 +47,6 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     static final String HTTP_KEEPALIVE_CONF = "splunk.hec.http.keepalive";
     static final String HEC_THREDS_CONF = "splunk.hec.threads";
     static final String SOCKET_TIMEOUT_CONF = "splunk.hec.socket.timeout"; // seconds
-    static final String SESSION_VALIDATION_TIMEOUT = "session.validation.timeout.ms";
-    static final int SESSION_VALIDATION_TIMEOUT_DEFAULT = 5000;
     static final String CONNECTION_TIMEOUT_CONF = "splunk.hec.connection.timeout"; // seconds
     static final String CONNECTION_REQUEST_TIMEOUT_CONF = "splunk.hec.connection.request.timeout"; // seconds
     static final String SSL_VALIDATE_CERTIFICATES_CONF = "splunk.hec.ssl.validate.certs";
@@ -197,7 +195,6 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
     final boolean httpKeepAlive;
     final int numberOfThreads;
     final int socketTimeout;
-    final int socketTimeoutForValidation;
     final int connectionTimeout;
     final int connectionRequestTimeout;
     final boolean validateCertificates;
@@ -254,7 +251,6 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
         flushWindow = getInt(FLUSH_WINDOW_CONF);
         totalHecChannels = getInt(TOTAL_HEC_CHANNEL_CONF);
         socketTimeout = getInt(SOCKET_TIMEOUT_CONF);
-        socketTimeoutForValidation = getInt(SESSION_VALIDATION_TIMEOUT);
         connectionTimeout = getInt(CONNECTION_TIMEOUT_CONF);
         connectionRequestTimeout = getInt(CONNECTION_REQUEST_TIMEOUT_CONF);
         enrichments = parseEnrichments(getString(ENRICHMENT_CONF));
@@ -317,8 +313,7 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
                 .define(HEADER_SOURCETYPE_CONF, ConfigDef.Type.STRING, "splunk.header.sourcetype", ConfigDef.Importance.MEDIUM, HEADER_SOURCETYPE_DOC)
                 .define(HEADER_HOST_CONF, ConfigDef.Type.STRING, "splunk.header.host", ConfigDef.Importance.MEDIUM, HEADER_HOST_DOC)
                 .define(LB_POLL_INTERVAL_CONF, ConfigDef.Type.INT, 120, ConfigDef.Importance.LOW, LB_POLL_INTERVAL_DOC)
-                .define(ENABLE_COMPRESSSION_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, ENABLE_COMPRESSSION_DOC)
-                .defineInternal(SESSION_VALIDATION_TIMEOUT, ConfigDef.Type.INT, SESSION_VALIDATION_TIMEOUT_DEFAULT, ConfigDef.Importance.LOW);
+                .define(ENABLE_COMPRESSSION_CONF, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.MEDIUM, ENABLE_COMPRESSSION_DOC);
     }
 
     /**
@@ -347,10 +342,12 @@ public final class SplunkSinkConnectorConfig extends AbstractConfig {
 
     public HecConfig getHecConfigForValidate() {
         HecConfig config = new HecConfig(Arrays.asList(splunkURI.split(",")), splunkToken);
+        // 10 second timeouts for all validation operations to prevent hanging
+        int validationTimeoutSeconds = 10;
         config.setDisableSSLCertVerification(!validateCertificates)
-            .setSocketTimeout(socketTimeoutForValidation)
-            .setConnectionTimeout(connectionTimeout)
-            .setConnectionRequestTimeout(connectionRequestTimeout)
+            .setSocketTimeout(validationTimeoutSeconds)
+            .setConnectionTimeout(validationTimeoutSeconds)
+            .setConnectionRequestTimeout(validationTimeoutSeconds)
             .setMaxHttpConnectionPerChannel(maxHttpConnPerChannel)
             .setTotalChannels(totalHecChannels)
             .setEventBatchTimeout(eventBatchTimeout)

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -296,12 +296,12 @@ class SplunkSinkConnecterTest {
         Map<String, String> connectorConfig = getConnectorConfig();
 
         SplunkSinkConnectorConfig config = new SplunkSinkConnectorConfig(connectorConfig);
-        com.splunk.hecclient.HecConfig hecConfigForValidate = config.getHecConfigForValidate();
+        HecConfig hecConfigForValidate = config.getHecConfigForValidate();
         
         // Verify that validation uses hardcoded 10 second timeouts for all operations
-        Assert.assertEquals("Socket timeout for validation should be 5 seconds", 10, hecConfigForValidate.getSocketTimeout());
-        Assert.assertEquals("Connection timeout for validation should be 5 seconds", 10, hecConfigForValidate.getConnectionTimeout());
-        Assert.assertEquals("Connection request timeout for validation should be 5 seconds", 10, hecConfigForValidate.getConnectionRequestTimeout());
+        Assert.assertEquals("Socket timeout for validation should be 10 seconds", 10, hecConfigForValidate.getSocketTimeout());
+        Assert.assertEquals("Connection timeout for validation should be 10 seconds", 10, hecConfigForValidate.getConnectionTimeout());
+        Assert.assertEquals("Connection request timeout for validation should be 10 seconds", 10, hecConfigForValidate.getConnectionRequestTimeout());
         
         // Compare with regular HecConfig which should have 60 second (default) timeouts
         HecConfig regularHecConfig = config.getHecConfig();

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -16,6 +16,7 @@
 package com.splunk.kafka.connect;
 
 import com.splunk.hecclient.HecException;
+import com.splunk.hecclient.HecConfig;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -288,6 +289,25 @@ class SplunkSinkConnecterTest {
 
         assertTrue(errorMessages.get(SplunkSinkConnectorConfig.SSL_TRUSTSTORE_PATH_CONF).get(0).contains("Configuration validation error"));
         assertTrue(errorMessages.get(SplunkSinkConnectorConfig.SSL_TRUSTSTORE_PASSWORD_CONF).get(0).contains("Configuration validation error"));
+    }
+
+    @Test
+    public void testValidationTimeoutConfiguration() {
+        Map<String, String> connectorConfig = getConnectorConfig();
+
+        SplunkSinkConnectorConfig config = new SplunkSinkConnectorConfig(connectorConfig);
+        com.splunk.hecclient.HecConfig hecConfigForValidate = config.getHecConfigForValidate();
+        
+        // Verify that validation uses hardcoded 10 second timeouts for all operations
+        Assert.assertEquals("Socket timeout for validation should be 5 seconds", 5, hecConfigForValidate.getSocketTimeout());
+        Assert.assertEquals("Connection timeout for validation should be 5 seconds", 5, hecConfigForValidate.getConnectionTimeout());
+        Assert.assertEquals("Connection request timeout for validation should be 5 seconds", 5, hecConfigForValidate.getConnectionRequestTimeout());
+        
+        // Compare with regular HecConfig which should have 60 second (default) timeouts
+        HecConfig regularHecConfig = config.getHecConfig();
+        Assert.assertEquals("Regular socket timeout should be 60 seconds", 60, regularHecConfig.getSocketTimeout());
+        Assert.assertEquals("Regular connection timeout should be 60 seconds", 60, regularHecConfig.getConnectionTimeout());
+        Assert.assertEquals("Regular connection request timeout should be 60 seconds", 60, regularHecConfig.getConnectionRequestTimeout());
     }
 
     private Map<String, String> getConnectorConfig() {

--- a/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
+++ b/src/test/java/com/splunk/kafka/connect/SplunkSinkConnecterTest.java
@@ -299,9 +299,9 @@ class SplunkSinkConnecterTest {
         com.splunk.hecclient.HecConfig hecConfigForValidate = config.getHecConfigForValidate();
         
         // Verify that validation uses hardcoded 10 second timeouts for all operations
-        Assert.assertEquals("Socket timeout for validation should be 5 seconds", 5, hecConfigForValidate.getSocketTimeout());
-        Assert.assertEquals("Connection timeout for validation should be 5 seconds", 5, hecConfigForValidate.getConnectionTimeout());
-        Assert.assertEquals("Connection request timeout for validation should be 5 seconds", 5, hecConfigForValidate.getConnectionRequestTimeout());
+        Assert.assertEquals("Socket timeout for validation should be 5 seconds", 10, hecConfigForValidate.getSocketTimeout());
+        Assert.assertEquals("Connection timeout for validation should be 5 seconds", 10, hecConfigForValidate.getConnectionTimeout());
+        Assert.assertEquals("Connection request timeout for validation should be 5 seconds", 10, hecConfigForValidate.getConnectionRequestTimeout());
         
         // Compare with regular HecConfig which should have 60 second (default) timeouts
         HecConfig regularHecConfig = config.getHecConfig();


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-35771
Adding separate timeout for validation client. 
Earlier validation timeout was set 5000 ms but the client takes in second hence it resulted in 5000 sec timeout. 
Now, validation timeout is set to 10 sec.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy

kafka docker playground test

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
